### PR TITLE
add panoply error class with retryable attribute

### DIFF
--- a/panoply/errors.py
+++ b/panoply/errors.py
@@ -1,0 +1,4 @@
+class PanoplyException(Exception):
+    def __init__(self, args=None, retryable=True):
+        super(PanoplyException, self).__init__(args)
+        self.retryable = retryable


### PR DESCRIPTION
All python sources that raise an exception are still pending in the client since panoply is looking for a retryable attribute which is defaulted to True.
This PR adds a PanoplyException class which includes the retryable attribute.

To make use of this new class, one would have to `raise PanoplyException('my exception', retryable=False)`

This new class should be imported from panoply.errors

It is used in the new Dunnhumby source (which should be merged once this PR is merged)