### PR TITLE
python-sdk readme api key generation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ conn.write( "tablename", { "foo": "bar" } )
 ```
 #### Generating an API Key and Secret
 
-While logged into the panoply platform, click to add a new data source.  Select the Panoply SDK as your data source. This will automatically generate and display in your browser an API key and API secret. Use this key and secret to instantiate SDK objects.
+While logged into the Panoply.io platform, click to add a new data source.  Select the Panoply SDK as your data source. This will automatically generate and display in your browser an API key and API secret. Use this key and secret to instantiate SDK objects.
 
 #### API
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ SQS-based Python SDK for streaming data in realtime to the Panoply platform
 ```
 $ python setup.py install
 ```
+
 #### Usage
 
 ```python

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ SQS-based Python SDK for streaming data in realtime to the Panoply platform
 ```
 $ python setup.py install
 ```
-
 #### Usage
 
 ```python
@@ -14,6 +13,9 @@ import panoply
 conn = panoply.SDK( "APIKEY", "APISECRET" )
 conn.write( "tablename", { "foo": "bar" } )
 ```
+#### Generating an API Key and Secret
+
+While logged into the panoply platform, click to add a new data source.  Select the Panoply SDK as your data source. This will automatically generate and display in your browser an API key and API secret. Use this key and secret to instantiate SDK objects.
 
 #### API
 


### PR DESCRIPTION
added notes on how to generate API Key and API Secret since this isn't obvious if reading the readme before attempting to add sdk as a data source. 

