### PR TITLE
Process files though 2to3 tool to convert to python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
-python: 3
+python: 3.6
 
 branches:
  only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
-python: 2.7
+python: 3
 
 branches:
  only:

--- a/panoply/__init__.py
+++ b/panoply/__init__.py
@@ -1,2 +1,2 @@
-from datasource import *
-from sdk import *
+from .datasource import *
+from .sdk import *

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -1,6 +1,6 @@
-import events
+from . import events
 import requests
-from errors import PanoplyException
+from .errors import PanoplyException
 import traceback
 
 
@@ -104,7 +104,7 @@ def validate_token(refresh_url, exceptions=(), callback=None,
                         _callback(self.source.get(access_key))
 
                     return f(*args)
-                except Exception, e:
+                except Exception as e:
                     self.log('Error: Access token can\'t be revalidated. '
                              'The user would have to re-authenticate',
                              traceback.format_exc())

--- a/panoply/sdk.py
+++ b/panoply/sdk.py
@@ -1,10 +1,11 @@
 import base64
 import json
 import time
-import urllib.request, urllib.error, urllib.parse
+import urllib.request
+import urllib.error
+import urllib.parse
 import threading
 import queue
-import logging
 from copy import copy
 from .constants import __package_name__, __version__
 

--- a/panoply/sdk.py
+++ b/panoply/sdk.py
@@ -1,14 +1,14 @@
 import base64
 import json
 import time
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import threading
-import Queue
+import queue
 import logging
 from copy import copy
-from constants import __package_name__, __version__
+from .constants import __package_name__, __version__
 
-import events
+from . import events
 
 MAXSIZE = 1024 * 250  # 250kib
 FLUSH_TIMEOUT = 2.0   # 2 seconds
@@ -35,7 +35,7 @@ class SDK(events.Emitter):
         # decompose the api key and secret
         # api-key: ACCOUNT/RAND1
         # api-secret: BASE64( RAND2/UUID/AWSACCOUNT/REGION )
-        decoded = base64.b64decode(apisecret).split("/")
+        decoded = base64.b64decode(apisecret).decode().split("/")
         rand = decoded[0]
         awsaccount = decoded[2]
         region = decoded[3]
@@ -50,7 +50,7 @@ class SDK(events.Emitter):
             rand
         )
 
-        self._buffer = Queue.Queue()
+        self._buffer = queue.Queue()
         thread = threading.Thread(target=self._sendloop)
         thread.daemon = True
         thread.start()
@@ -60,7 +60,7 @@ class SDK(events.Emitter):
         data = copy(data)
         data["__table"] = table
         data = json.dumps(data).encode("utf-8")
-        data = urllib2.quote(data)
+        data = urllib.parse.quote(data)
         self._buffer.put(data + "\n")
 
     # flush the buffer to SQS
@@ -80,18 +80,18 @@ class SDK(events.Emitter):
             "MessageAttribute.3.Value.StringValue=" + pack,
         ]
 
-        body = "&".join(body)
+        body = bytearray("&".join(body), "utf-8")
 
         headers = {
             "Content-Length": len(body),
             "Content-Type": "application/x-www-form-urlencoded"
         }
-        print "SENDING NOW"
+        print("SENDING NOW")
 
-        req = urllib2.Request(self.qurl, body, headers)
+        req = urllib.request.Request(self.qurl, body, headers)
         self.fire("send", {"req": req})
         try:
-            res = urllib2.urlopen(req)
+            res = urllib.request.urlopen(req)
         except Exception as err:
             self.fire("error", err)
             return
@@ -106,7 +106,7 @@ class SDK(events.Emitter):
             try:
                 data = buf.get(True, FLUSH_TIMEOUT)  # blocking
                 body += data + "\n"
-            except Queue.Empty:
+            except queue.Empty:
                 pass
 
             length = len(body)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-execfile('panoply/constants.py')
+exec(compile(open('panoply/constants.py').read(), 'panoply/constants.py', 'exec'))
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from distutils.core import setup
 
-exec(compile(open('panoply/constants.py').read(), 'panoply/constants.py', 'exec'))
+CONSTATNTS = 'panoply/constants.py'
+exec(compile(open(CONSTATNTS).read(), CONSTATNTS, 'exec'))
 
 
 setup(

--- a/test.py
+++ b/test.py
@@ -7,7 +7,6 @@ SECRET = "MmM0NWNvc2wwYmJ4ZDJ0OS84MmY3MzQ4NC02MDIzLTQyN2QtODdkMS0yY2I0NTAzNDk0ND
 sdk = panoply.SDK(KEY, SECRET)
 sdk.write('roi-test', {'hello': 1})
 
-
 print(sdk.qurl)
 
 time.sleep(5)

--- a/test.py
+++ b/test.py
@@ -8,6 +8,6 @@ sdk = panoply.SDK(KEY, SECRET)
 sdk.write('roi-test', {'hello': 1})
 
 
-print sdk.qurl
+print(sdk.qurl)
 
 time.sleep(5)


### PR DESCRIPTION
All files were processed though the 2to3 tool in order to support python3.

Additional modifications were needed due to changes in the `base64` and `urllib` modules - both now utilize byte types.