### PR TITLE
State reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ Writes a message to the log. It's advised to add log lines extensively in order 
 
 Update the progress of the data source during calls to `read()`. It's used by the UI to show a progress bar, and for internal monitoring. You want to call `.progress()` at least once per `read()` call. `loaded` and `total` are integers, representing the number of resources loaded out of the total number of resources. It can be anything, like db rows, files, API calls, etc. `msg` is an optional human-readable text describing the progress status, for example: `3,000/6,000 files loaded`. For the best user experience, it is advised to provide a clear and coherent message.
 
+###### state(self, state_id, state)
+Report the current state of the data collection. Each state that is reported should have a **unique** `state_id` across the entire process.
+
+For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
+`{"state_id": "unique_id`, "state": {"table": "users", "loaded" 500}}`. With this state object, the data source would be able to use the `loaded` value
+as a `SKIP` or `OFFSET` parameter.
+
 ###### fire(self, type, data)
 
 Fire an event of type `type` with the specified `data`.

--- a/README.md
+++ b/README.md
@@ -106,13 +106,18 @@ Writes a message to the log. It's advised to add log lines extensively in order 
 Update the progress of the data source during calls to `read()`. It's used by the UI to show a progress bar, and for internal monitoring. You want to call `.progress()` at least once per `read()` call. `loaded` and `total` are integers, representing the number of resources loaded out of the total number of resources. It can be anything, like db rows, files, API calls, etc. `msg` is an optional human-readable text describing the progress status, for example: `3,000/6,000 files loaded`. For the best user experience, it is advised to provide a clear and coherent message.
 
 ###### state(self, state_id, state)
-Report the current state of the data collection. Each state that is reported should have a **unique** `state_id` across the entire process.
-Each data object returned by the source should contain a `__state` key with the value of the current `state_id` of the batch that is being returned.
-Note that every state object that is reported is **merged into one** - this allows for incremental updates to the progress of each resource.
+
+Report the current state of the data collection.
+
+- Each state that is reported should have a **unique** `state_id` across the entire process.
+- Each data object returned by the source should contain a `__state` key with the value of the current `state_id` of the batch that is being returned.
+- Note that every state object that is reported is **merged into one** - this allows for incremental updates to the progress of each resource.
 
 For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
-`{"state_id": "unique_id`, "state": {"table": "users", "loaded" 500}}`. With this state object, the data source would be able to use the `loaded` value
-as a `SKIP` or `OFFSET` parameter.
+
+    {"state_id": "unique_id`, "state": {"table": "users", "loaded": 500}}
+
+With this state object, the data source would be able to use the `loaded` value as a `SKIP` or `OFFSET` parameter.
 
 ###### fire(self, type, data)
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ Writes a message to the log. It's advised to add log lines extensively in order 
 
 Update the progress of the data source during calls to `read()`. It's used by the UI to show a progress bar, and for internal monitoring. You want to call `.progress()` at least once per `read()` call. `loaded` and `total` are integers, representing the number of resources loaded out of the total number of resources. It can be anything, like db rows, files, API calls, etc. `msg` is an optional human-readable text describing the progress status, for example: `3,000/6,000 files loaded`. For the best user experience, it is advised to provide a clear and coherent message.
 
-###### state(self, state)
-Report the current state of the data collection. For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
+###### state(self, state_id, state)
+Report the current state of the data collection. Each state that is reported should have a **unique** `state_id` across the entire process.
+
+For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
 `{"state_id": "unique_id`, "state": {"table": "users", "loaded" 500}}`. With this state object, the data source would be able to use the `loaded` value
 as a `SKIP` or `OFFSET` parameter.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Update the progress of the data source during calls to `read()`. It's used by th
 
 ###### state(self, state_id, state)
 Report the current state of the data collection. Each state that is reported should have a **unique** `state_id` across the entire process.
+Each data object returned by the source should contain a `__state` key with the value of the current `state_id` of the batch that is being returned.
 
 For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
 `{"state_id": "unique_id`, "state": {"table": "users", "loaded" 500}}`. With this state object, the data source would be able to use the `loaded` value

--- a/README.md
+++ b/README.md
@@ -105,10 +105,8 @@ Writes a message to the log. It's advised to add log lines extensively in order 
 
 Update the progress of the data source during calls to `read()`. It's used by the UI to show a progress bar, and for internal monitoring. You want to call `.progress()` at least once per `read()` call. `loaded` and `total` are integers, representing the number of resources loaded out of the total number of resources. It can be anything, like db rows, files, API calls, etc. `msg` is an optional human-readable text describing the progress status, for example: `3,000/6,000 files loaded`. For the best user experience, it is advised to provide a clear and coherent message.
 
-###### state(self, state_id, state)
-Report the current state of the data collection. Each state that is reported should have a **unique** `state_id` across the entire process.
-
-For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
+###### state(self, state)
+Report the current state of the data collection. For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
 `{"state_id": "unique_id`, "state": {"table": "users", "loaded" 500}}`. With this state object, the data source would be able to use the `loaded` value
 as a `SKIP` or `OFFSET` parameter.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Update the progress of the data source during calls to `read()`. It's used by th
 ###### state(self, state_id, state)
 Report the current state of the data collection. Each state that is reported should have a **unique** `state_id` across the entire process.
 Each data object returned by the source should contain a `__state` key with the value of the current `state_id` of the batch that is being returned.
+Note that every state object that is reported is **merged into one** - this allows for incremental updates to the progress of each resource.
 
 For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
 `{"state_id": "unique_id`, "state": {"table": "users", "loaded" 500}}`. With this state object, the data source would be able to use the `loaded` value

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Report the current state of the data collection.
 
 For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:
 
-    {"state_id": "unique_id`, "state": {"table": "users", "loaded": 500}}
+    # Note that `tableName` is used as a key so that merging this state object
+    # into previous ones will override the loaded value.
+    {"state_id": "unique_id`, "state": { "tableName": "loaded": 500}}
 
 With this state object, the data source would be able to use the `loaded` value as a `SKIP` or `OFFSET` parameter.
 

--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "1.3.4"
+__version__ = "1.4.0"
 __package_name__ = "panoply-python-sdk"

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -1,4 +1,3 @@
-import time
 import events
 import requests
 from errors import PanoplyException
@@ -25,8 +24,7 @@ class DataSource(events.Emitter):
         else:
             print(msgs)
 
-    def state(self, state):
-        state_id = str(time.time())
+    def state(self, state_id, state):
         self.fire('source-state', {
             "stateId": state_id,
             "state": state

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -24,6 +24,12 @@ class DataSource(events.Emitter):
         else:
             print(msgs)
 
+    def state(self, state_id, state):
+        self.fire('source-state', {
+            "stateId": state_id,
+            "state": state
+        })
+
     def progress(self, loaded, total, msg=''):
         self.fire('progress', {
             'loaded': loaded,

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -1,3 +1,4 @@
+import time
 import events
 import requests
 from errors import PanoplyException
@@ -24,7 +25,8 @@ class DataSource(events.Emitter):
         else:
             print(msgs)
 
-    def state(self, state_id, state):
+    def state(self, state):
+        state_id = str(time.time())
         self.fire('source-state', {
             "stateId": state_id,
             "state": state


### PR DESCRIPTION
These changes add the ability for a data source to report its status to the platform. 

- Each state that is reported should have a **unique** `state_id` across the entire process.
- Each data object returned by the source should contain a `__state` key with the value of the current `state_id` of the batch that is being returned.
- Note that every state object that is reported is **merged into one** - this allows for incremental updates to the progress of each resource.

For supported data sources, in the event of a failure, data collection is retried and this state object is provided together with the source dict to allow for the data source to continue from where it left off. An example of a state object would be the name of the current resource (tablename/api endpoint) and the number of data objects already fetched:

```
# Note that `tableName` is used as a key so that merging this state object
# into previous ones will override the loaded value.

{"state_id": "unique_id`, "state": { "tableName": "loaded": 500}}
```

With this state object, the data source would be able to use the `loaded` value as a `SKIP` or `OFFSET` parameter.