### PR TITLE
Encode raw messages in base64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 
 # C extensions
 *.so
-
+.idea/
 # Distribution / packaging
 .Python
 env/

--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 __package_name__ = "panoply-python-sdk"

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -1,3 +1,5 @@
+import base64
+
 import events
 import requests
 import traceback
@@ -40,7 +42,7 @@ class DataSource(events.Emitter):
 
     def raw(self, tag, raw, metadata):
         """ Create a raw response object """
-
+        raw = base64.b64encode(raw)
         return {
             'type': 'raw',
             'tag': tag,

--- a/test.py
+++ b/test.py
@@ -7,8 +7,6 @@ SECRET = "MmM0NWNvc2wwYmJ4ZDJ0OS84MmY3MzQ4NC02MDIzLTQyN2QtODdkMS0yY2I0NTAzNDk0ND
 sdk = panoply.SDK(KEY, SECRET)
 sdk.write('roi-test', {'hello': 1})
 
-
-
 print sdk.qurl
 
 time.sleep(5)

--- a/test.py
+++ b/test.py
@@ -8,6 +8,7 @@ sdk = panoply.SDK(KEY, SECRET)
 sdk.write('roi-test', {'hello': 1})
 
 
+
 print sdk.qurl
 
 time.sleep(5)


### PR DESCRIPTION
## Issues addressed
* https://app.asana.com/0/327352447154397/482335517277126
* https://app.asana.com/0/727412460998567/868829501148356
* Probably others

## Description - What does this PR do?
This PR encodes the `content` of all raw messages in base64. Currently, binary data is encoded incorrectly by the SDK.

* Bumped minor version