### PR TITLE
Support Python3

### DIFF
--- a/panoply/__init__.py
+++ b/panoply/__init__.py
@@ -1,2 +1,2 @@
-from datasource import *
-from sdk import *
+from . datasource import *
+from . sdk import *

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -1,6 +1,6 @@
 import base64
 
-from . events import events
+from . events import *
 import requests
 import traceback
 from . errors import PanoplyException

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -1,6 +1,6 @@
 import base64
 
-from . events from events
+from . events import events
 import requests
 import traceback
 from . errors import PanoplyException

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -1,12 +1,12 @@
 import base64
 
-import events
+from . events from events
 import requests
 import traceback
-from errors import PanoplyException
+from . errors import PanoplyException
 
 
-class DataSource(events.Emitter):
+class DataSource(Emitter):
     """ A base DataSource object """
 
     def __init__(self, source, options={}):
@@ -123,7 +123,7 @@ def validate_token(refresh_url, exceptions=(), callback=None,
                         _callback(self.source.get(access_key))
 
                     return f(*args)
-                except Exception, e:
+                except Exception as e:
                     self.log('Error: Access token can\'t be revalidated. '
                              'The user would have to re-authenticate',
                              traceback.format_exc())

--- a/panoply/sdk.py
+++ b/panoply/sdk.py
@@ -1,20 +1,19 @@
 import base64
 import json
 import time
-import urllib2
+from urllib.request import urlopen
 import threading
-import Queue
+import queue
 import logging
 from copy import copy
-from constants import __package_name__, __version__
-
-import events
+from . constants import __package_name__, __version__
+from . events import *
 
 MAXSIZE = 1024 * 250  # 250kib
 FLUSH_TIMEOUT = 2.0   # 2 seconds
 
 
-class SDK(events.Emitter):
+class SDK(Emitter):
 
     account = None
     apikey = None
@@ -86,7 +85,7 @@ class SDK(events.Emitter):
             "Content-Length": len(body),
             "Content-Type": "application/x-www-form-urlencoded"
         }
-        print "SENDING NOW"
+        print("SENDING NOW")
 
         req = urllib2.Request(self.qurl, body, headers)
         self.fire("send", {"req": req})

--- a/panoply/sdk.py
+++ b/panoply/sdk.py
@@ -50,7 +50,7 @@ class SDK(Emitter):
             rand
         )
 
-        self._buffer = Queue.Queue()
+        self._buffer = queue.Queue()
         thread = threading.Thread(target=self._sendloop)
         thread.daemon = True
         thread.start()
@@ -106,7 +106,7 @@ class SDK(Emitter):
             try:
                 data = buf.get(True, FLUSH_TIMEOUT)  # blocking
                 body += data + "\n"
-            except Queue.Empty:
+            except queue.Empty:
                 pass
 
             length = len(body)

--- a/panoply/sdk.py
+++ b/panoply/sdk.py
@@ -1,7 +1,8 @@
 import base64
 import json
 import time
-from urllib.request import urlopen
+import urllib.request
+import urllib.parse
 import threading
 import queue
 import logging
@@ -34,7 +35,7 @@ class SDK(Emitter):
         # decompose the api key and secret
         # api-key: ACCOUNT/RAND1
         # api-secret: BASE64( RAND2/UUID/AWSACCOUNT/REGION )
-        decoded = base64.b64decode(apisecret).split("/")
+        decoded = base64.b64decode(apisecret).decode("utf-8").split("/")
         rand = decoded[0]
         awsaccount = decoded[2]
         region = decoded[3]
@@ -59,7 +60,7 @@ class SDK(Emitter):
         data = copy(data)
         data["__table"] = table
         data = json.dumps(data).encode("utf-8")
-        data = urllib2.quote(data)
+        data = urllib.parse.quote(data)
         self._buffer.put(data + "\n")
 
     # flush the buffer to SQS
@@ -87,10 +88,10 @@ class SDK(Emitter):
         }
         print("SENDING NOW")
 
-        req = urllib2.Request(self.qurl, body, headers)
+        req = urllib.request.Request(self.qurl, body, headers)
         self.fire("send", {"req": req})
         try:
-            res = urllib2.urlopen(req)
+            res = urllib.request.urlopen(req)
         except Exception as err:
             self.fire("error", err)
             return

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-execfile('panoply/constants.py')
-
+exec(open("panoply/constants.py").read())
 
 setup(
     name=__package_name__,


### PR DESCRIPTION
We have a few python3 scripts we use for etl purposes and a couple legacy python2 ones that were using this sdk. I updated all of scripts and this sdk to be compatible with python3. I could totally be missing something and I'm very unfamiliar with the python ecosystem so not sure if you handle upgrades in a different way, but I updated the paths we use and related errors.

*Important:* This would be a breaking change so would bump the version to reflect.

Happy to make some more updates if you can find anything.


For others, you can test out these changes by adding this to your requirements.txt:

```
git+https://github.com/Moment-Inc/panoply-python-sdk.git@master
```

or just running

```
pip3 install git+https://github.com/Moment-Inc/panoply-python-sdk.git@master
```

then you can import like a normal module `import panoply`