### PR TITLE
replace execfile() with exec()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-execfile('panoply/constants.py')
-
+exec(open('panoply/constants.py').read())
 
 setup(
     name=__package_name__,


### PR DESCRIPTION
Execfile is deprecated in Python 3. According to the [official python documentation ](https://docs.python.org/3.3/whatsnew/3.0.html?highlight=execfile#builtins), `exec(open(fn).read())` must be used instead.