### PR TITLE
Handle errors inside the source

### DIFF
--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __package_name__ = "panoply-python-sdk"

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -121,8 +121,6 @@ def validate_token(refresh_url, exceptions=(), callback=None,
                         else:
                             _callback = getattr(self, callback)
                         _callback(self.source.get(access_key))
-
-                    return f(*args)
                 except Exception as e:
                     self.log('Error: Access token can\'t be revalidated. '
                              'The user would have to re-authenticate',
@@ -131,5 +129,7 @@ def validate_token(refresh_url, exceptions=(), callback=None,
                     raise PanoplyException(
                         'access token could not be refreshed ({})'
                         .format(str(e)), retryable=False)
+
+                return f(*args)
         return wrapper
     return _validate_token


### PR DESCRIPTION
Jira issue [DS-520](https://panoply.atlassian.net/browse/DS-520)
## Description
This change is applied to the functions which are wrapped with `validate_token` decorator. If just after the revalidation process the error, which is not related to the access_token, occurs in the function the source will raise error `PanoplyException(access token could not be refreshed (<original error meassage>)`. (For example, `access token could not be refreshed (<HttpError 403 when requesting..."The caller does not have permission">))`. 
After this update we will be able to handle original errors in the source.