### PR TITLE
[DS-945] Panoply-python-sdk - Retry request for access_token refreshment

### DIFF
--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.0"
+__version__ = "2.0.2"
 __package_name__ = "panoply-python-sdk"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     packages=["panoply"],
     install_requires=[
         "requests==2.21.0",
-        "oauth2client==4.1.1"
+        "oauth2client==4.1.1",
+        "backoff==1.10.0"
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Jira issue: [DS-945](https://panoply.atlassian.net/browse/DS-945)

## Description
This change is applied to the functions which are wrapped with `validate_token` decorator. For better handling of back-end errors - adding backoff to retry request on token revalidation and raising response status in case of request failure. 