### PR TITLE
[UM-487] Fix syntax warning during source code compilation

### DIFF
--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.11"
+__version__ = "2.0.12"
 __package_name__ = "panoply-python-sdk"

--- a/panoply/sdk.py
+++ b/panoply/sdk.py
@@ -114,7 +114,7 @@ class SDK(events.Emitter):
             length = len(body)
             elapsed = time.time() - lastsend
 
-            if length is 0:
+            if length == 0:
                 # reset the time when there's nothing to send
                 lastsend = time.time()
             elif length > MAXSIZE or elapsed > FLUSH_TIMEOUT:


### PR DESCRIPTION
###### Jira Issue: [UM-487](https://panoply.atlassian.net/browse/UM-487)

## Description

- Fix syntax warning in source code

---

To keep source images smaller we are removing all .pyc files during builds and that means that they will be create again during first run of the source. The syntax warning causes source to fail on first run.