### PR TITLE
[um-570] update paramiko version

### DIFF
--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.14"
+__version__ = "2.0.15"
 __package_name__ = "panoply-python-sdk"

--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.13"
+__version__ = "2.0.14"
 __package_name__ = "panoply-python-sdk"

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ setup(
         "oauth2client==4.1.1",
         "backoff==1.10.0",
         "sshtunnel==0.1.5",
-        "paramiko==2.7.2",
-        "cryptography==36.0.2",
+        "paramiko==2.11.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
following the P1 we had due to deprication of cryptography package In paramiko package.
paramiko released a fix in version 2.11.0
so we are updating it in our SDK

tested on:

- [ ] bigquery
- [ ] es
- [ ] generichttp
- [x] google_analyticsv2
- [x] googlesheetsv2
- [ ] hubspotv2
- [x] jira
- [x] mongov3
- [ ] mssqlv2
- [ ] mysqlv2
- [x] postgresv2
- [ ] sftpv2
- [ ] shopifyv2