### PR TITLE
[UM-601] Fix nested error wrappers overwrite original error

### DIFF
--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.13"
+__version__ = "2.0.14"
 __package_name__ = "panoply-python-sdk"

--- a/panoply/errors/error_normalization.py
+++ b/panoply/errors/error_normalization.py
@@ -56,6 +56,11 @@ def wrap_errors(phase: Phase) -> callable:
         def wrapper(*args, **kwargs) -> list:
             try:
                 return func(*args, **kwargs)
+            except DataSourceException as e:
+                # In case of nested error wrapper we should keep the original
+                # error but with the phase value of the last error wrapper
+                e.phase = phase.value
+                raise e
             except Exception as e:
                 # source object can be:
                 # 1. a first param in dynamic params methods (e.g. definition(source, options))


### PR DESCRIPTION
# Description

- Fix nested error wrappers overwrite original error

---

In case of nested error wrapper we should keep the original error but with the phase value of the last error wrapper.

This can happen if function of `config` phase initializes source where `__init__` function is wrapped with `collect` phase value.