### PR TITLE
[DS-3139] Add timeout to background progress: Fixed error with renaming variable

### DIFF
--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -179,7 +179,7 @@ def background_progress(message, waiting_interval=10 * 60, timeout=24*60*60):
         def wrapper(*args, **kwargs):
             self = args[0]
             self.log('Creating background progress emitter')
-            self.log(f'Timeout is set to {max_wait} seconds')
+            self.log(f'Timeout is set to {timeout} seconds')
             finished = Event()
             started_at = time()
             with ThreadPoolExecutor(max_workers=1) as executor:


### PR DESCRIPTION
See description: https://github.com/panoplyio/panoply-python-sdk/pull/51