### PR TITLE
[PAN-1649] - added logs for invalid token

### DIFF
--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "3.1.2"
+__version__ = "3.1.3"
 __package_name__ = "panoply-python-sdk"

--- a/panoply/datasource.py
+++ b/panoply/datasource.py
@@ -163,6 +163,9 @@ def validate_token(refresh_url, exceptions=(), callback=None,
                             _callback = getattr(self, callback)
                         _callback(self.source.get(access_key))
                 except Exception as e:
+                    response = getattr(e, 'response', None)
+                    if isinstance(response, requests.Response):
+                        self.log(response.text)
                     self.log('Error: Access token can\'t be revalidated. '
                              'The user would have to re-authenticate',
                              traceback.format_exc())


### PR DESCRIPTION
# Description

- [List of all changes]
Added logging response body if revalidating token request returns invalid response

[Additional information about changes]
Linkedin has 5 different description on 400 http error ([link](https://learn.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens?context=linkedin%2Fcontext))
We cannot see [body of response](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/kubernetes/log-events/kubernetes.var.log.containers.job-51008532-1678756479_platform_panoply-worker-5c78fd95934f08a4cc6b7cbbe08bdf20730249528393208a8257ad4fb5279283.log$3Fstart$3D-86400000)
## Related PRs

- [List of related pull requests]

## Tasks

- [[PAN-1649](https://panoply.atlassian.net/browse/PAN-1649)] 


[PAN-1649]: https://panoply.atlassian.net/browse/PAN-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ