### PR TITLE
 [PAN-1904] Configurables are failing due to unhandled errors from Python data sources

### DIFF
--- a/panoply/__init__.py
+++ b/panoply/__init__.py
@@ -1,5 +1,34 @@
+import logging
+
+from sys import stdout
+from traceback import print_exception as _print_exception
+
 from .datasource import *
 from .records import *
 from .resources import *
 from .sdk import *
 from .ssh import SSHTunnel
+
+
+logging.basicConfig(stream=stdout, format='%(levelname)s: %(message)s')
+
+
+def custom_excepthook(args, /):
+    """
+    Handle uncaught Thread.run() exception
+    and print error text to STDOUT instead of STDERR.
+    "It's always assumed that
+    the runnner is single-threaded and synchronuous such that `result` events
+    are only assigned to the last executed request".
+    see https://github.com/panoplyio/legacy-source-wrapper/blob/master/src/sources-runner/index.js#L74
+    """
+    if args.exc_type == SystemExit:
+        # silently ignore SystemExit
+        return
+
+    logging.error(f"Caught an exception in thread:")
+    _print_exception(args.exc_type, args.exc_value, args.exc_traceback,
+                     file=stdout)
+
+
+threading.excepthook = custom_excepthook

--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "3.1.3"
+__version__ = "3.1.4"
 __package_name__ = "panoply-python-sdk"


### PR DESCRIPTION
jira issue: [PAN-1904](https://panoply.atlassian.net/browse/PAN-1904)

# Description
- Add this to `__init__.py` so we override threading err handling in every source that uses python-sdk
- Add console logger with STDOUT stream

[PAN-1904]: https://panoply.atlassian.net/browse/PAN-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ