### PR TITLE
Hardcode crypthography to 42.0.8

### DIFF
--- a/panoply/constants.py
+++ b/panoply/constants.py
@@ -1,2 +1,2 @@
-__version__ = "3.1.3"
+__version__ = "3.1.4"
 __package_name__ = "panoply-python-sdk"

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "backoff==1.10.0",
         "sshtunnel==0.1.5",
         "paramiko==2.11.0",
+        "cryptography == 42.0.8",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
# Description
Hardcore cryptography version to 42.0.8 to avoid error:
`/opt/app/ve/lib/python3.8/site-packages/paramiko/pkey.py:82: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0. "cipher": algorithms.TripleDES, /opt/app/ve/lib/python3.8/site-packages/paramiko/transport.py:253: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0. "class": algorithms.TripleDES, `

- [List of all changes]

---

[Additional information about changes]

## Related PRs

- [List of related pull requests]

## Tasks

- [ ] [List of tasks that must be done before merging this pull request]
